### PR TITLE
Removed 'dummy' span in CreateLink.tsx

### DIFF
--- a/src/components/CreateLink.tsx
+++ b/src/components/CreateLink.tsx
@@ -105,11 +105,6 @@ const CreateLink: NextPage = () => {
               Already in use.
             </span>
           )}
-          {!slugCheck.data?.used && (
-            <span className="font-medium text-center text-red-500 text-transparent select-none">
-              dummy
-            </span>
-          )}
         </span>
         <div className="flex items-center -mt-2">
           <span className="font-medium whitespace-nowrap mr-1">


### PR DESCRIPTION
The 'dummy' text was found in the src/components/CreateLink.tsx file. So, I removed the corresponding span tag in that file